### PR TITLE
mac版钱包打开时报错:  Library not loaded: @loader_path/libboost_system-mt.dylib

### DIFF
--- a/build-aux/m4/ax_boost_filesystem.m4
+++ b/build-aux/m4/ax_boost_filesystem.m4
@@ -82,14 +82,14 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
             ax_lib=
             if test "x$ax_boost_user_filesystem_lib" = "x"; then
-                for libextension in `ls -r $BOOSTLIBDIR/libboost_filesystem* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_filesystem-mt* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],
                                  [link_filesystem="no"])
 				done
                 if test "x$link_filesystem" != "xyes"; then
-                for libextension in `ls -r $BOOSTLIBDIR/boost_filesystem* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
+                for libextension in `ls -r $BOOSTLIBDIR/boost_filesystem-mt* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],

--- a/build-aux/m4/ax_boost_system.m4
+++ b/build-aux/m4/ax_boost_system.m4
@@ -85,14 +85,14 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 			LDFLAGS_SAVE=$LDFLAGS
             if test "x$ax_boost_user_system_lib" = "x"; then
                 ax_lib=
-                for libextension in `ls -r $BOOSTLIBDIR/libboost_system* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_system-mt* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
                                  [link_system="no"])
 				done
                 if test "x$link_system" != "xyes"; then
-                for libextension in `ls -r $BOOSTLIBDIR/boost_system* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
+                for libextension in `ls -r $BOOSTLIBDIR/boost_system-mt* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],


### PR DESCRIPTION
问题：mac版本只找到libboost_system.dylib,

解决：编译连接直接链接到libboost_system-mt.dylib,
make deploy直接打包的libboost_system-mt.dylib，分发安装时就带libboost_system-mt.dylib,而不是libboost_system.dylib。

